### PR TITLE
Add SEO and social metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,19 @@ permission from the copyright holder.
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Farina Tennis</title>
+  <meta name="description" content="Clases de tenis personalizadas con el instructor Adrián Farina en Tucumán, Yerba Buena y Tafí Viejo. Clases particulares, grupales, infantiles y tenis delivery a domicilio.">
+  <meta name="keywords" content="tenis, clases de tenis, Adrián Farina, Tucumán, Yerba Buena, Tafí Viejo, tenis delivery, clases particulares, clases grupales, clases de tenis tucuman, clases de tenis yerba buena, clases de tenis tafi viejo, clases de tenis a domicilio, profesor de tenis en tucuman, instructor de tenis tucuman, clases de tenis para niños tucuman, clases de tenis infantil tucuman">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://farinatennis.com.ar/">
+  <meta property="og:title" content="Farina Tennis">
+  <meta property="og:description" content="Clases de tenis personalizadas con el instructor Adrián Farina en Tucumán, Yerba Buena y Tafí Viejo. Clases particulares, grupales, infantiles y tenis delivery a domicilio.">
+  <meta property="og:image" content="https://farinatennis.com.ar/img/6d77dd2cef3ce1348489e7000e9215be.jpg">
+  <meta property="og:url" content="https://farinatennis.com.ar/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Farina Tennis">
+  <meta name="twitter:description" content="Clases de tenis personalizadas con el instructor Adrián Farina en Tucumán, Yerba Buena y Tafí Viejo. Clases particulares, grupales, infantiles y tenis delivery a domicilio.">
+  <meta name="twitter:image" content="https://farinatennis.com.ar/img/6d77dd2cef3ce1348489e7000e9215be.jpg">
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     img {
@@ -191,7 +204,7 @@ permission from the copyright holder.
   <section id="contact" class="max-w-7xl mx-auto px-6 py-20 text-center">
     <h3 class="text-3xl font-bold mb-6">¿Listo para jugar?</h3>
       <p class="mb-6 text-gray-800">Contactame y reservá tu lugar en la cancha.</p>
-    <a href="mailto:info@farinatennis.com" class="bg-blue-600 text-white px-6 py-3 rounded-full shadow hover:bg-blue-700 transition">Quiero agendar una clase</a>
+    <a href="mailto:adrian@farinatennis.com.ar" class="bg-blue-600 text-white px-6 py-3 rounded-full shadow hover:bg-blue-700 transition">Quiero agendar una clase</a>
   </section>
 
   <!-- Footer -->


### PR DESCRIPTION
## Summary
- broaden meta description and social summaries to include Yerba Buena and Tafí Viejo service areas
- expand SEO keywords with additional location and service phrases
- correct canonical and social image URLs to use farinatennis.com.ar domain
- update contact link to adrian@farinatennis.com.ar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24ef692f0832fbe71078b4eaa2a09